### PR TITLE
allow mutation context manager, release 2025.1.1

### DIFF
--- a/constantdict/__init__.py
+++ b/constantdict/__init__.py
@@ -27,18 +27,20 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 """
 
-try:
+import sys
+from collections.abc import Iterable
+from typing import Any, Dict, Hashable, TypeVar  # <3.9 needs Dict, not dict
+
+if sys.version_info >= (3, 8):
     import importlib.metadata as importlib_metadata
-except ModuleNotFoundError:  # pragma: no cover
-    # Python 3.7
+    from typing import Literal
+else:  # pragma: no cover
     import importlib_metadata  # type: ignore[no-redef]
+    from typing_extensions import Literal
+
 
 __version__ = importlib_metadata.version(__package__ or __name__)
 
-
-import sys
-from collections.abc import Iterable
-from typing import Any, Dict, Hashable, Literal, TypeVar  # <3.9 needs Dict, not dict
 
 K = TypeVar("K", bound=Hashable)
 V = TypeVar("V", covariant=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "constantdict"
-version = "2025.1"
+version = "2025.1.1"
 authors = [
   { name="Matthias Diener", email="matthias.diener@gmail.com" },
 ]
@@ -47,7 +47,7 @@ extend-select = [
 ]
 
 extend-ignore = [
-  "N801",
+  "N801",  # Class name should use CapWords convention
 ]
 
 [tool.ruff.lint.flake8-quotes]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,8 @@ authors = [
 ]
 description = "An immutable dict class."
 dependencies = [
-    "importlib_metadata;python_version<'3.8'"
+    "importlib_metadata;python_version<'3.8'",
+    "typing_extensions;python_version<'3.8'"
 ]
 readme = "README.md"
 license = { file="LICENSE" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,8 +24,9 @@ classifiers = [
 ]
 
 [project.urls]
-"Homepage" = "https://github.com/matthiasdiener/constantdict/"
-"Bug Tracker" = "https://github.com/matthiasdiener/constantdict/issues"
+Homepage = "https://github.com/matthiasdiener/constantdict"
+Documentation = "https://matthiasdiener.github.io/constantdict"
+Issues = "https://github.com/matthiasdiener/constantdict/issues"
 
 [tool.ruff]
 preview = true

--- a/test/test_constantdict.py
+++ b/test/test_constantdict.py
@@ -290,6 +290,10 @@ def test_mutation() -> None:
 
     with cd.mutate() as cdm:
         cdm["a"] = 42
+        del cdm["b"]
+        cd_new = cdm.finish()
+
+    assert cd_new == {"a": 42}
 
 
 def test_uncached_hash() -> None:

--- a/test/test_constantdict.py
+++ b/test/test_constantdict.py
@@ -293,6 +293,7 @@ def test_mutation() -> None:
         del cdm["b"]
         cd_new = cdm.finish()
 
+    assert cd == {"a": 1, "b": 2}
     assert cd_new == {"a": 42}
 
 

--- a/test/test_constantdict.py
+++ b/test/test_constantdict.py
@@ -288,6 +288,9 @@ def test_mutation() -> None:
 
     assert cd == {"a": 1, "b": 2}
 
+    with cd.mutate() as cdm:
+        cdm["a"] = 42
+
 
 def test_uncached_hash() -> None:
     cduh = constantdictuncachedhash(a=1, b=2)


### PR DESCRIPTION
Based on the [`immutables.Map`](https://github.com/MagicStack/immutables?tab=readme-ov-file#api) API.

cc @inducer @alexfikl

Fixes #37.

After merging this PR:

```
REL=2025.1.1 && git checkout main && git pull && git tag -a v$REL -m "Release v$REL" && git push --tags

pip wheel . && twine upload constantdict-$REL*
```